### PR TITLE
Compatibility with Gazebo 9 libraries

### DIFF
--- a/ridgeback_gazebo_plugins/include/ridgeback_gazebo_plugins/ridgeback_ros_force_based_move.h
+++ b/ridgeback_gazebo_plugins/include/ridgeback_gazebo_plugins/ridgeback_ros_force_based_move.h
@@ -30,8 +30,6 @@
 #include <boost/thread.hpp>
 #include <map>
 
-// #include <ignition/math/Pose3.hh>
-// #include <ignition/math/Vector3.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/physics/physics.hh>
 #include <sdf/sdf.hh>

--- a/ridgeback_gazebo_plugins/include/ridgeback_gazebo_plugins/ridgeback_ros_force_based_move.h
+++ b/ridgeback_gazebo_plugins/include/ridgeback_gazebo_plugins/ridgeback_ros_force_based_move.h
@@ -30,6 +30,8 @@
 #include <boost/thread.hpp>
 #include <map>
 
+// #include <ignition/math/Pose3.hh>
+// #include <ignition/math/Vector3.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/physics/physics.hh>
 #include <sdf/sdf.hh>
@@ -104,7 +106,7 @@ namespace gazebo {
       double rot_;
       bool alive_;
       common::Time last_odom_publish_time_;
-      math::Pose last_odom_pose_;
+      ignition::math::Pose3d last_odom_pose_;
 
       double torque_yaw_velocity_p_gain_;
       double force_x_velocity_p_gain_;

--- a/ridgeback_gazebo_plugins/src/ridgeback_ros_force_based_move.cpp
+++ b/ridgeback_gazebo_plugins/src/ridgeback_ros_force_based_move.cpp
@@ -155,8 +155,8 @@ namespace gazebo
       this->publish_odometry_tf_ = sdf->GetElement("publishOdometryTf")->Get<bool>();
     }
 
-    last_odom_publish_time_ = parent_->GetWorld()->GetSimTime();
-    last_odom_pose_ = parent_->GetWorldPose();
+    last_odom_publish_time_ = parent_->GetWorld()->SimTime();
+    last_odom_pose_ = parent_->WorldPose();
     x_ = 0.0;
     y_ = 0.0;
     rot_ = 0.0;
@@ -207,35 +207,35 @@ namespace gazebo
   void GazeboRosForceBasedMove::UpdateChild()
   {
     boost::mutex::scoped_lock scoped_lock(lock);
-    math::Pose pose = parent_->GetWorldPose();
+    ignition::math::Pose3d pose = parent_->WorldPose();
 
-    if ((parent_->GetWorld()->GetSimTime() - last_cmd_vel_time_) > cmd_vel_time_out_) {
+    if ((parent_->GetWorld()->SimTime() - last_cmd_vel_time_) > cmd_vel_time_out_) {
       x_ = 0.0;
       y_ = 0.0;
       rot_ = 0.0;
     }
 
-    math::Vector3 angular_vel = parent_->GetWorldAngularVel();
-    link_->AddTorque(math::Vector3(0.0,
+    ignition::math::Vector3d angular_vel = parent_->WorldAngularVel();
+    link_->AddTorque(ignition::math::Vector3d(0.0,
                                    0.0,
-                                   (rot_ - angular_vel.z) * torque_yaw_velocity_p_gain_));
+                                   (rot_ - angular_vel.Z()) * torque_yaw_velocity_p_gain_));
 
     // float yaw = pose.rot.GetYaw();
 
-    math::Vector3 linear_vel = parent_->GetRelativeLinearVel();
+    ignition::math::Vector3d linear_vel = parent_->RelativeLinearVel();
 
-    link_->AddRelativeForce(math::Vector3((x_ - linear_vel.x)* force_x_velocity_p_gain_,
-                                          (y_ - linear_vel.y)* force_y_velocity_p_gain_,
+    link_->AddRelativeForce(ignition::math::Vector3d((x_ - linear_vel.X())* force_x_velocity_p_gain_,
+                                          (y_ - linear_vel.Y())* force_y_velocity_p_gain_,
                                           0.0));
     //parent_->PlaceOnNearestEntityBelow();
-    //parent_->SetLinearVel(math::Vector3(
+    //parent_->SetLinearVel(ignition::math::Vector3d(
     //      x_ * cosf(yaw) - y_ * sinf(yaw),
     //      y_ * cosf(yaw) + x_ * sinf(yaw),
     //      0));
-    //parent_->SetAngularVel(math::Vector3(0, 0, rot_));
+    //parent_->SetAngularVel(ignition::math::Vector3d(0, 0, rot_));
 
     if (odometry_rate_ > 0.0) {
-      common::Time current_time = parent_->GetWorld()->GetSimTime();
+      common::Time current_time = parent_->GetWorld()->SimTime();
       double seconds_since_last_update =
         (current_time - last_odom_publish_time_).Double();
       if (seconds_since_last_update > (1.0 / odometry_rate_)) {
@@ -261,7 +261,7 @@ namespace gazebo
     x_ = cmd_msg->linear.x;
     y_ = cmd_msg->linear.y;
     rot_ = cmd_msg->angular.z;
-    last_cmd_vel_time_= parent_->GetWorld()->GetSimTime();
+    last_cmd_vel_time_= parent_->GetWorld()->SimTime();
   }
 
   void GazeboRosForceBasedMove::QueueThread()
@@ -281,14 +281,14 @@ namespace gazebo
     std::string base_footprint_frame =
       tf::resolve(tf_prefix_, robot_base_frame_);
 
-    math::Vector3 angular_vel = parent_->GetRelativeAngularVel();
-    math::Vector3 linear_vel = parent_->GetRelativeLinearVel();
+    ignition::math::Vector3d angular_vel = parent_->RelativeAngularVel();
+    ignition::math::Vector3d linear_vel = parent_->RelativeLinearVel();
 
-    odom_transform_= odom_transform_ * this->getTransformForMotion(linear_vel.x, angular_vel.z, step_time);
+    odom_transform_= odom_transform_ * this->getTransformForMotion(linear_vel.X(), angular_vel.Z(), step_time);
 
     tf::poseTFToMsg(odom_transform_, odom_.pose.pose);
-    odom_.twist.twist.angular.z = angular_vel.z;
-    odom_.twist.twist.linear.x  = linear_vel.x;
+    odom_.twist.twist.angular.z = angular_vel.Z();
+    odom_.twist.twist.linear.x  = linear_vel.X();
 
     odom_.header.stamp = current_time;
     odom_.header.frame_id = odom_frame;
@@ -306,7 +306,7 @@ namespace gazebo
     odom_.pose.covariance[21] = 1000000000000.0;
     odom_.pose.covariance[28] = 1000000000000.0;
 
-    if (std::abs(angular_vel.z) < 0.0001) {
+    if (std::abs(angular_vel.Z()) < 0.0001) {
       odom_.pose.covariance[35] = 0.01;
     }else{
       odom_.pose.covariance[35] = 100.0;
@@ -318,7 +318,7 @@ namespace gazebo
     odom_.twist.covariance[21] = 1000000000000.0;
     odom_.twist.covariance[28] = 1000000000000.0;
 
-    if (std::abs(angular_vel.z) < 0.0001) {
+    if (std::abs(angular_vel.Z()) < 0.0001) {
       odom_.twist.covariance[35] = 0.01;
     }else{
       odom_.twist.covariance[35] = 100.0;


### PR DESCRIPTION
Hey,
I tried to build the ridgeback_gazebo_plugins sub-package under Ubuntu 18.04.1 and ROS Melodic, and wasn't able to. I found out that the API for Gazebo math changed and was separated into the new ignition math libraries. I made some changes to fix the include errors, following these directives:

https://github.com/siconos/gazebo-siconos/blob/master/ign-math-migration.md

There isn't much documentation on the functionality of the plugin, so I haven't tested it yet. Can you provide some input to verify that the pull request preserves the functionality?

PD: I'm requesting merge into kinetic-devel, because there is no melodic-devel branch yet. 

Thank you.
Yoshua Nava