### PR TITLE
incorrect libgazeboX-dev dependency for melodic

### DIFF
--- a/ridgeback_gazebo_plugins/package.xml
+++ b/ridgeback_gazebo_plugins/package.xml
@@ -15,7 +15,7 @@
 
   <!-- Dependencies needed to compile this package. -->
   <build_depend>roscpp</build_depend>
-  <build_depend>libgazebo7-dev</build_depend>
+  <build_depend>libgazebo9-dev</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>geometry_msgs</build_depend>


### PR DESCRIPTION
rigeback gazebo plugins for melodic should be attached to libgazebo9-dev instead to libgazebo7-dev