### PR TITLE
[CMake Warning] conditionally set CMP0054

### DIFF
--- a/mecanum_gazebo_plugin/CMakeLists.txt
+++ b/mecanum_gazebo_plugin/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mecanum_gazebo_plugin)
 
+if (POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 find_package(catkin REQUIRED COMPONENTS rosconsole roslint)
 find_package(gazebo)
 

--- a/ridgeback_gazebo_plugins/CMakeLists.txt
+++ b/ridgeback_gazebo_plugins/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ridgeback_gazebo_plugins)
 
+if (POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages


### PR DESCRIPTION
This fixes the warning from CMake >= 3.1
rviz was fixed the same way - see https://github.com/ros/catkin/pull/729