### PR TITLE
Improved mecanum wheel model

### DIFF
--- a/mecanum_gazebo_plugin/CMakeLists.txt
+++ b/mecanum_gazebo_plugin/CMakeLists.txt
@@ -5,9 +5,7 @@ find_package(catkin REQUIRED COMPONENTS rosconsole roslint)
 find_package(gazebo)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
-catkin_package(
-   #LIBRARIES mecanum_gazebo_plugin
-)
+catkin_package()
 
 include_directories(
   ${catkin_INCLUDE_DIRS}

--- a/mecanum_gazebo_plugin/CMakeLists.txt
+++ b/mecanum_gazebo_plugin/CMakeLists.txt
@@ -3,9 +3,10 @@ project(mecanum_gazebo_plugin)
 
 find_package(catkin REQUIRED COMPONENTS rosconsole roslint)
 find_package(gazebo)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
 catkin_package(
-  #  LIBRARIES mecanum_gazebo_plugin
+   #LIBRARIES mecanum_gazebo_plugin
 )
 
 include_directories(
@@ -13,15 +14,15 @@ include_directories(
   ${GAZEBO_INCLUDE_DIRS}
 )
 
-#add_library(${PROJECT_NAME} src/mecanum_plugin)
-#target_link_libraries(${PROJECT_NAME}
-#  ${catkin_LIBRARIES}
-#  ${GAZEBO_LIBRARIES}
-#)
+add_library(${PROJECT_NAME} src/mecanum_plugin)
+target_link_libraries(${PROJECT_NAME}
+ ${catkin_LIBRARIES}
+ ${GAZEBO_LIBRARIES}
+)
 
-# roslint_cpp()
-# roslint_add_test()
+roslint_cpp()
+roslint_add_test()
 
-#install(TARGETS ${PROJECT_NAME}
-#  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#)
+install(TARGETS ${PROJECT_NAME}
+ LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)

--- a/mecanum_gazebo_plugin/package.xml
+++ b/mecanum_gazebo_plugin/package.xml
@@ -2,10 +2,11 @@
 <package format="2">
   <name>mecanum_gazebo_plugin</name>
   <version>0.1.1</version>
-  <description>Plugin which uses directional friction to simulate mecanum wheels.</description>
+  <description>Plugin which uses a passive revolute joint aligned with the roller and a shphere shape to simulate mecanum wheels.</description>
 
-  <maintainer email="mpurvis@clearpathrobotics.com">Mike Purvis</maintainer>
+  <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>
   <author>Mike Purvis</author>
+  <author>Vladimir Ivan</author>
 
   <license>BSD</license>
 
@@ -13,6 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslint</build_depend>
+  <build_depend>libgazebo9-dev</build_depend>
   <depend>gazebo</depend>
   <depend>rosconsole</depend>
 </package>

--- a/mecanum_gazebo_plugin/package.xml
+++ b/mecanum_gazebo_plugin/package.xml
@@ -4,7 +4,7 @@
   <version>0.1.1</version>
   <description>Plugin which uses a passive revolute joint aligned with the roller and a shphere shape to simulate mecanum wheels.</description>
 
-  <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>
+  <maintainer email="mpurvis@clearpathrobotics.com">Mike Purvis</maintainer>
   <author>Mike Purvis</author>
   <author>Vladimir Ivan</author>
 

--- a/mecanum_gazebo_plugin/readme.md
+++ b/mecanum_gazebo_plugin/readme.md
@@ -1,0 +1,88 @@
+# Macanum Gazebo Plugin
+
+This plugin simulates a mecanum wheel using a passive roller joint and a sphere collision shape.
+For this to work, the wheel URDF has to be modified as follows:
+
+ - The wheel joint should be `continuous` and acutated, e.g. using a transmission with an approriate hardware interface and the ros_control plugin.
+ - The wheel link should contain the visual elelment and a dummy mass and inertia but no collision shape.
+ - A second `continuous` joint should be added with zero origin. The axis is not important but as a convention it should be the same as the wheel joint axis. The joint should have a proxy roller link as a child.
+ - The proxy roller link should contain the wheel mass and inertia. It should also contain a sphere collision shape whe the same radius as the wheel.
+
+ The proxy roller link emulates the passive rolling of the wheel. This plugin will then align the axis of the passive joint so that it matches with the axis of the roller that would be in contact with ground. 
+ 
+ The plugin has two parameters:
+  - `wheelLinkName`: the name of the wheel link
+  - `axis`: axis of the passive roller joint in the wheel frame, e.g., for mecanum wheels at 45deg angle this would be `[1 1 0]` (or similar, depending on how the wheel is mounted). The axis will be normalized.
+
+Friction parameters can be tuned via gazebo in the URDF. The wheel control can be set up and tuned to match the robot using ros_control and its gazebo plugin. The sphere collision model is not an accurate representation of the mecanum wheel. It allows the wheel to drive over obstacles sideways and the curvature of the sphere may not match the curvature of the rollers for all widths. It does allow the wheel to drive on uneven terrain and model the friction and it produces motion very similar to the real world behaviour.
+
+This plugin can also be used to simulate omni wheels by specifying the axis to be perpendicular to wheel axis.
+
+### Example
+
+Additional link and joint in the URDF:
+```
+<!-- Proxy roller link -->
+<link name="wheel_link_fl_passive">
+    <inertial>
+        <mass value="10.0"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <inertia ixx="0.0441" ixy="0" ixz="0" iyy="0.0441" iyz="0" izz="0.0441"/>
+    </inertial>
+    <visual>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+        <sphere radius="0.001"/>
+        </geometry>
+        <transparency>1</transparency>
+    </visual>
+    <collision>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+        <sphere radius="0.105"/>
+        </geometry>
+    </collision>
+</link>
+
+<!-- Passive joint -->
+<joint name="wheel_joint_fl_passive" type="continuous">
+    <axis xyz="0 1 0"/>
+    <limit effort="100" velocity="100"/>
+    <dynamics damping="0.0" friction="0.0"/>
+    <safety_controller k_velocity="10.0"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="wheel_link_fl"/>
+    <child link="wheel_link_fl_passive"/>
+</joint>
+
+<!-- Actuation of the wheel -->
+<transmission name="wheel_joint_fl_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="wheel_joint_fl">
+    <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="wheel_joint_fl_motor">
+    <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+</transmission>
+```
+
+Plugin configuration for 4 mecanum wheels:
+```
+<plugin name="wheel_controller_fl" filename="libmecanum_gazebo_plugin.so">
+    <wheelLinkName>wheel_link_fl</wheelLinkName>
+    <axis>-1 1 0</axis>
+</plugin>
+<plugin name="wheel_controller_fr" filename="libmecanum_gazebo_plugin.so">
+    <wheelLinkName>wheel_link_fr</wheelLinkName>
+    <axis>-1 -1 0</axis>
+</plugin>
+<plugin name="wheel_controller_rl" filename="libmecanum_gazebo_plugin.so">
+    <wheelLinkName>wheel_link_rl</wheelLinkName>
+    <axis>1 1 0</axis>
+</plugin>
+<plugin name="wheel_controller_rr" filename="libmecanum_gazebo_plugin.so">
+    <wheelLinkName>wheel_link_rr</wheelLinkName>
+    <axis>1 -1 0</axis>
+</plugin>
+```

--- a/mecanum_gazebo_plugin/src/mecanum_plugin.cpp
+++ b/mecanum_gazebo_plugin/src/mecanum_plugin.cpp
@@ -126,7 +126,7 @@ void MecanumPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 
 void MecanumPlugin::GazeboUpdate()
 {
-  // Re-align the passive hoint axis
+  // Re-align the passive joint axis
   passive_joint_->SetAxis(0, axis_);
 }
 

--- a/mecanum_gazebo_plugin/src/mecanum_plugin.cpp
+++ b/mecanum_gazebo_plugin/src/mecanum_plugin.cpp
@@ -57,6 +57,14 @@ void MecanumPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
   // Store the model
   model_ = _parent;
 
+  auto physics = model_->GetWorld()->Physics()->GetType();
+  if (physics != "ode" && physics != "dart")
+  {
+    ROS_FATAL("Only ODE and Dart physics engines are supported with mecanum wheels!");
+    return;
+  }
+
+
   std::string link_name;
 
   if (_sdf->HasElement("wheelLinkName"))


### PR DESCRIPTION
- Changed to use a passive rolling ball as a model instead of modifying the friction
- Removed the following parameters: fixedLinkName, rollerAngle, rollerFriction, rollerSkidFriction
- Added axis parameter
- Removed dependency on ODE
- Updated for compatibility with Gazebo 9
- Added readme
- Updated changelog
- Did not change version number
- Only supported for ODE and Dart